### PR TITLE
Fix field usage on prepared input types

### DIFF
--- a/lib/graphql/analysis/ast/field_usage.rb
+++ b/lib/graphql/analysis/ast/field_usage.rb
@@ -48,7 +48,7 @@ module GraphQL
               argument_type = argument_type.of_type
             end
 
-            if argument_type.kind.input_object?
+            if argument_type.kind.input_object? && argument.value.respond_to?(:arguments) # Skip if value is not a GraphQL::Schema::InputObject
               extract_deprecated_arguments(argument.value.arguments.argument_values) # rubocop:disable Development/ContextIsPassedCop -- runtime args instance
             elsif argument_type.kind.enum?
               extract_deprecated_enum_value(argument_type, argument.value)

--- a/spec/graphql/analysis/ast/field_usage_spec.rb
+++ b/spec/graphql/analysis/ast/field_usage_spec.rb
@@ -254,15 +254,15 @@ describe GraphQL::Analysis::AST::FieldUsage do
     end
   end
 
-  describe "mutation with deprecated arguments with prepared values" do
+  describe "mutation with deprecated arguments with prepared values does not break" do
     let(:query_string) {%|
       mutation {
         pushValue(preparedTestInput: { deprecatedDate: "2020-10-10" })
       }
     |}
 
-    it "keeps track of nested deprecated arguments" do
-      assert_equal ['PreparedDateInput.deprecatedDate'], result[:used_deprecated_arguments]
+    it "does not keeps track of nested deprecated arguments" do
+      assert_equal [], result[:used_deprecated_arguments]
     end
   end
 

--- a/spec/graphql/analysis/ast/field_usage_spec.rb
+++ b/spec/graphql/analysis/ast/field_usage_spec.rb
@@ -254,6 +254,17 @@ describe GraphQL::Analysis::AST::FieldUsage do
     end
   end
 
+  describe "mutation with deprecated arguments with prepared values" do
+    let(:query_string) {%|
+      mutation {
+        pushValue(preparedTestInput: { deprecatedDate: "2020-10-10" })
+      }
+    |}
+
+    it "keeps track of nested deprecated arguments" do
+      assert_equal ['PreparedDateInput.deprecatedDate'], result[:used_deprecated_arguments]
+    end
+  end
 
   describe "when an argument prepare raises a GraphQL::ExecutionError" do
     class ArgumentErrorFieldUsageSchema < GraphQL::Schema

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -265,6 +265,18 @@ module Dummy
     argument :old_source, String, required: false, deprecation_reason: "No longer supported"
   end
 
+  class PreparedDateInput < BaseInputObject
+    description "Input with prepared value"
+    argument :date, String, description: "date as a string", required: false
+    argument :deprecated_date, String, description: "date as a string", required: false, deprecation_reason: "Use date"
+
+    def prepare
+      return nil unless date || deprecated_date
+
+      Date.parse(date || deprecated_date)
+    end
+  end
+
   class DeepNonNull < BaseObject
     field :non_null_int, Integer, null: false do
       argument :returning, Integer, required: false
@@ -490,6 +502,7 @@ module Dummy
     field :push_value, [Integer], null: false, description: "Push a value onto a global array :D" do
       argument :value, Integer, as: :val
       argument :deprecated_test_input, DairyProductInput, required: false
+      argument :prepared_test_input, PreparedDateInput, required: false
     end
     def push_value(val:)
       GLOBAL_VALUES << val


### PR DESCRIPTION
**Note**

This fix just prevents `FieldUsage` from breaking when an `InputType` is preparing a value.

A bug report has been submitted https://github.com/rmosolgo/graphql-ruby/issues/4864